### PR TITLE
Add textarea input type compatibility in Touch UI

### DIFF
--- a/src/main/content/jcr_root/etc/clientlibs/multicomposite-touchui/js/CUI.Multicompositefield.js
+++ b/src/main/content/jcr_root/etc/clientlibs/multicomposite-touchui/js/CUI.Multicompositefield.js
@@ -155,7 +155,7 @@
                     $('.multicompositefield-field', this).each(function() {
                         var contentPath = $(this).data('content-path');
 
-                        $('input,select', this).each(function() {
+                        $('input,select,textarea', this).each(function() {
                             if (endsWith(contentPath, $(this).attr('name'))
                                     || $(this).attr('name')
                                         .match(new RegExp(contentPath.replace('#', '[0-9]*'), 'g'))) {


### PR DESCRIPTION
The field name rewrite in the js rewrites the name attribute for specific tag types. Input and Span were correctly included, but textarea was not initially included.
